### PR TITLE
feat:直播页标签改为:平台+直播间名称

### DIFF
--- a/src/components/LivePage/Room.vue
+++ b/src/components/LivePage/Room.vue
@@ -206,6 +206,7 @@ export default {
             this.roomId = response.data.data.roomId
             let flag = (response.data.data.isFollowed == 1)
             this.followed = flag
+            this.changeTitle(response.data.data.roomName)
           }
         })
       this.initBan()
@@ -560,7 +561,11 @@ export default {
         case 100:
           return "无限"
       }
-    }
+    },
+    changeTitle(roomName) {
+      const platform = this.getPlatform(this.$route.query.platform)
+      document.title = `${platform}+${roomName}`
+    } 
   },
   created() {
     this.listenerFunction();


### PR DESCRIPTION
#229 
直播页标签改为:平台+直播间名称
![Snipaste_2023-04-10_13-46-11](https://user-images.githubusercontent.com/73629147/230838601-6f6b46d5-0fb5-469e-8a69-bdb6188c5157.png)
![Snipaste_2023-04-10_13-46-47](https://user-images.githubusercontent.com/73629147/230838637-f373598b-82fa-43db-bbe5-fdaa6ae8da32.png)
